### PR TITLE
Fujiテーマをforkしたものを参照する, 最新のHugoに追従する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Build and deploy
 
 on:
   push:
-    branches: 
+    branches:
       - main
       - master
   pull_request:
@@ -24,16 +24,16 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-    
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.119.0'
+          hugo-version: '0.153.2'
           extended: true
 
       - name: Build
         run: hugo --minify
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "themes/fuji"]
-	path = themes/fuji
-	url = https://github.com/dsrkafuu/hugo-theme-fuji.git
-

--- a/content/post/2024-12-26-comiket105.md
+++ b/content/post/2024-12-26-comiket105.md
@@ -1,7 +1,6 @@
 ---
 title: "C105参加のお知らせ"
 date: 2024-12-26T19:27:36+09:00
-author: urandom
 author: yyu
 tags:
   - Publication

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/urandom-ctf/urandom-ctf.github.io
+
+go 1.25.5

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/urandom-ctf/urandom-ctf.github.io
 
 go 1.25.5
+
+require github.com/urandom-ctf/hugo-theme-fuji v0.0.0-20251225001953-9a0ee8ebfa73 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/urandom-ctf/hugo-theme-fuji v0.0.0-20251225001953-9a0ee8ebfa73 h1:a4J11+lVtHeMxx/wamAYQzqqkH/IvYX85UrwjKUMOgQ=
+github.com/urandom-ctf/hugo-theme-fuji v0.0.0-20251225001953-9a0ee8ebfa73/go.mod h1:DFg9ycvhpM7r13Xz6VFjx8sKi6FQwDFYjO1XuBWbDxM=

--- a/hugo.toml
+++ b/hugo.toml
@@ -13,9 +13,17 @@ languageCode = "ja-jp"  # For RSS, view https://www.rssboard.org/rss-language-co
 defaultContentLanguage = "en"  # For HTML page, now support: en, zh-hans, zh-hant, ja, nl, pl, it
 
 summaryLength = 100 # Custom summary length, add <!--more--> in post file to custom split point
-paginate = 10
 
 # googleAnalytics = "UA-000000000-0" # Set your Google Analytics UA here
+
+[pagination]
+  pagerSize = 10
+
+[module]
+  # Uncomment the following line and adjust the path to use local theme during development
+  # replacements = "github.com/urandom-ctf/hugo-theme-fuji -> ../../hugo-theme-fuji"
+  [[module.imports]]
+    path = "github.com/urandom-ctf/hugo-theme-fuji"
 
 [outputFormats]
   [outputFormats.SearchIndex]

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,7 +1,6 @@
 baseURL = "https://urandom.team"
 title = "urandom"
 
-theme = "fuji"
 hasCJKLanguage = true
 enableEmoji = true
 enableRobotsTXT = true


### PR DESCRIPTION
[オリジナルのFujiテーマ](https://github.com/dsrkafuu/hugo-theme-fuji)は最終コミットが3年前で、現在のHugoの変更に追従できていない。

このため、すでに廃止された機能を使っていたり、名前が変更された変数を参照したりしていて、ビルドが失敗している。

独自のforkを作り、これを参照するように変更した。

また、既存の設定も同様に最新のHugoでは廃止された設定値を使っているので、こちらも修正した。

最後に、なぜか2024-12-26のC105告知記事で、frontmatterに `author` がダブっていてエラーになっていたので、これもついでに修正した。

以上の修正と、Fork版Fujiテーマに修正を加えたものを参照することで、`hugo build`が成功することを確認した。